### PR TITLE
[GEP-26] Add support for workload identity

### DIFF
--- a/pkg/updater/credentials.go
+++ b/pkg/updater/credentials.go
@@ -53,9 +53,9 @@ type Credentials struct {
 
 // AccessKey represents static credentials for authentication to AWS.
 type AccessKey struct {
-	// ID is the key ID used for access to AWS.
+	// ID is the access key ID used for access to AWS.
 	ID string
-	// Secret is the secret used for access to AWS.
+	// Secret is the access key secret used for access to AWS.
 	Secret string
 }
 

--- a/pkg/updater/credentials.go
+++ b/pkg/updater/credentials.go
@@ -171,7 +171,7 @@ func NewAWSEC2V2(ctx context.Context, cred *Credentials, region string) (*ec2.Cl
 
 	config, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithEC2IMDSEndpointMode(imds.EndpointModeStateIPv6),
-		awsconfig.WithCredentialsProvider(aws.NewCredentialsCache(credentialsProvider)),
+		awsconfig.WithCredentialsProvider(credentialsProvider),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error loading default AWS config: %v", err)

--- a/pkg/updater/credentials.go
+++ b/pkg/updater/credentials.go
@@ -55,7 +55,7 @@ type Credentials struct {
 type AccessKey struct {
 	// ID is the access key ID used for access to AWS.
 	ID string
-	// Secret is the access key secret used for access to AWS.
+	// Secret is the secret access key used for access to AWS.
 	Secret string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new way of authentication against AWS based on workload (web) identity token and a role that is going to be assumed.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The controller now supports workload identity authentication.
```
