### PR TITLE
fix leader-election

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,18 +200,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create the stopCh channel
-	stopCh := make(chan struct{})
-
-	if leaderElection != nil && *leaderElection {
-		log.Info("Leader election is enabled")
-		go func() {
-			<-mgr.Elected()
-			cidrAllocator.Run(ctx, stopCh)
-		}()
-	} else {
-		log.Info("Leader election is disabled, running in single instance mode")
-		go cidrAllocator.Run(ctx, stopCh)
+	if err = mgr.Add(cidrAllocator); err != nil {
+		klog.Error(err, " could not add cidr allocator to manager")
+		os.Exit(1)
 	}
 
 	ctx = signals.SetupSignalHandler()


### PR DESCRIPTION
**What this PR does / why we need it**:
If multiple instances of the aws-ipam-controller run in parallel they try all to set the podCIDR on the kubernetes node object which leads to a race and could cause the same pod IP range to be assigned twice. To prevent this, this PR lets the CIDR allocator only run on the instance which holds the lease. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
CIDR allocator is only run on instance which gets elected as leader.
```
