### PR TITLE
update golang to v1.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG TARGETARCH
 RUN make release GOARCH=$TARGETARCH
 
 ############# aws-ipam-controller
-FROM gcr.io/distroless/static-debian11:nonroot AS aws-ipam-controller
+FROM gcr.io/distroless/static-debian12:nonroot AS aws-ipam-controller
 
 COPY --from=builder /build/aws-ipam-controller /aws-ipam-controller
 ENTRYPOINT ["/aws-ipam-controller"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/aws-ipam-controller
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.6

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -39,9 +39,9 @@ clean-tools-bin:
 
 # default tool versions
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.0.2
+GOLANGCI_LINT_VERSION ?= v2.5.0
 # renovate: datasource=github-releases depName=securego/gosec
-GOSEC_VERSION ?= v2.22.3
+GOSEC_VERSION ?= v2.22.9
 
 GOIMPORTS_VERSION ?= $(call version_gomod,golang.org/x/tools)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang to `v1.25.0` and static-debian image from 11 to 12.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Update golang to `v1.25.0` and static-debian image from 11 to 12.
```
