### PR TITLE
Cancel reconcileReady wait on controller shutdown

### DIFF
--- a/pkg/ipam/cidr_allocator.go
+++ b/pkg/ipam/cidr_allocator.go
@@ -132,9 +132,14 @@ type cidrAllocator struct {
 	primaryIPFamily      string
 	tickPeriod           time.Duration
 	nodeCIDRMaskSizeIPv6 int
-	// reconcileReady is closed after reconcileState completes. AllocateOrOccupyCIDR blocks on
-	// this before calling AllocateNext to prevent assigning CIDRs already held by existing nodes.
+	// reconcileReady is closed after reconcileState completes successfully. AllocateOrOccupyCIDR
+	// blocks on this before calling AllocateNext to prevent assigning CIDRs already held by
+	// existing nodes. If reconcileState fails, the channel is never closed; waiters unblock via
+	// startCtx instead so they don't leak.
 	reconcileReady chan struct{}
+	// startCtx is the context passed to Start. AllocateOrOccupyCIDR uses it to cancel the
+	// reconcileReady wait when the controller is shutting down.
+	startCtx context.Context
 }
 
 // NewCIDRRangeAllocator returns a CIDRAllocator to allocate CIDRs for node (one from each of clusterCIDRs)
@@ -190,6 +195,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client *coreV1Client.CoreV1Clien
 
 func (c *cidrAllocator) Start(ctx context.Context) error {
 	defer utilruntime.HandleCrash()
+	c.startCtx = ctx
 
 	klog.Infof("Starting CIDR allocator")
 	defer klog.Infof("Shutting down CIDR allocator")
@@ -337,8 +343,19 @@ func (c *cidrAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 	// Block allocation until reconcileState has finished populating the bitmap.
 	// Without this, a new node arriving concurrently with reconcileState could
 	// receive a CIDR already held by an existing node whose Occupy call hasn't
-	// been reached yet.
-	<-c.reconcileReady
+	// been reached yet. If the controller context is cancelled before reconcile
+	// completes (e.g. reconcileState returned an error and Start is unwinding),
+	// abort instead of blocking forever and leaking the goroutine.
+	if c.startCtx != nil {
+		select {
+		case <-c.reconcileReady:
+		case <-c.startCtx.Done():
+			c.removeNodeFromProcessing(node.Name)
+			return c.startCtx.Err()
+		}
+	} else {
+		<-c.reconcileReady
+	}
 
 	// allocate and queue the assignment
 	allocated := NodeReservedCIDRs{


### PR DESCRIPTION
Follow-up to #373.

## What this PR does / why we need it

#373 introduced a `reconcileReady` channel so that `AllocateOrOccupyCIDR` blocks until `reconcileState` has populated the bitmap, preventing duplicate CIDR assignments on restart. The receive is unconditional:

```go
<-c.reconcileReady
```

The channel is only closed if `reconcileState` returns successfully. If it errors — `List` failure, `Occupy` failure, context cancelled mid-reconcile — `Start` returns with the channel still open, and any informer goroutine already parked on the receive blocks forever. The goroutine holds a reference to the `*v1.Node` it was processing, so memory grows for the remaining lifetime of the process. The same hang occurs if the manager context is cancelled before reconcile completes.

This PR wraps the receive in a `select` against the `Start` context so waiters unblock on shutdown instead of leaking, and restores `nodesInProcessing` on the cancel path so a subsequent restart isn't poisoned by stale entries.

The narrow window where `AllocateOrOccupyCIDR` could fire before `Start` runs (informer handler registered before `mgr.Start`) is handled by a nil check that falls back to the previous unconditional receive — preserving #373's behavior in that case.

/area networking
/kind bug

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Pure goroutine-leak fix — no change to the happy-path allocation logic. Existing tests in `pkg/ipam` pass.

**Release note**:
```fix operator
Fixed a goroutine leak in the CIDR allocator: if state reconciliation failed or the controller context was cancelled mid-reconcile, in-flight node events would block forever on the reconcile-ready signal.
```