### PR TITLE
Adapt VPA resources to explicitly specify update mode `InPlaceOrRecreate`

### DIFF
--- a/Charts/gardener-extension-ipam-controller/values.yaml
+++ b/Charts/gardener-extension-ipam-controller/values.yaml
@@ -20,7 +20,7 @@ region: eu-west-1
 vpa:
   enabled: true
   updatePolicy:
-    updateMode: "Recreate"
+    updateMode: "InPlaceOrRecreate"
 
 resources:
   requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes in this PR explicitly set the update mode of the VPA resources to `InPlaceOrRecreate`. Doing so will allow us to remove the GRM webhook in a future release, as it is currently unconditionally enabled.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#12955

**Special notes for your reviewer**:
N/A

**Release note**:
```other operator
The update mode of the VerticalPodAutoscaler resources configured in aws-ipam-controller is now explicitly set to `InPlaceOrRecreate`, reflecting the actual runtime behavior after the unconditional enablement of the `VPAInPlaceUpdates` feature gate.
```
